### PR TITLE
App participants features

### DIFF
--- a/eurovision_project/settings.py
+++ b/eurovision_project/settings.py
@@ -192,9 +192,11 @@ CACHES = {
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient"
         },
-        "KEY_PREFIX": "example"
+        "KEY_PREFIX": "example",
+        "APPS_KEY_PREFIX": {'participants': 'participant'},
     }
 }
+
 
 # Cache time to live is 24 hours.
 CACHE_TTL = 86400

--- a/participants/admin.py
+++ b/participants/admin.py
@@ -7,7 +7,7 @@ from .models import Participant
 
 
 class ParticipantAdmin(admin.ModelAdmin):
-    list_display = ('__str__', 'view_total_score', 'total_voted',)
+    list_display = ('__str__', 'view_total_score', 'total_voted', 'cached_total_score',)
     list_filter = ('contest', 'contest__year', 'contest__host_country',)
     search_fields = ('contest__year', 'contest__host_country__name',)
 
@@ -25,6 +25,11 @@ class ParticipantAdmin(admin.ModelAdmin):
         return "%s / %s" % (obj.count_voted, obj.count_total_participants)
 
     total_voted.short_description = 'Voted'
+
+    def cached_total_score(self, obj):
+        return obj.cached_total_score
+
+    cached_total_score.short_description = 'Cached total score'
 
 
 admin.site.register(Participant, ParticipantAdmin)

--- a/participants/admin.py
+++ b/participants/admin.py
@@ -2,12 +2,13 @@ from django.contrib import admin
 from django.db.models import Sum
 from django.db.models import Value as V
 from django.db.models.functions import Coalesce
+from django.utils.safestring import mark_safe
 
 from .models import Participant
 
 
 class ParticipantAdmin(admin.ModelAdmin):
-    list_display = ('__str__', 'view_total_score', 'total_voted', 'cached_total_score',)
+    list_display = ('__str__', 'view_total_score', 'total_voted', 'cached_total_score', 'voted_ratio',)
     list_filter = ('contest', 'contest__year', 'contest__host_country',)
     search_fields = ('contest__year', 'contest__host_country__name',)
 
@@ -30,6 +31,17 @@ class ParticipantAdmin(admin.ModelAdmin):
         return obj.cached_total_score
 
     cached_total_score.short_description = 'Cached total score'
+
+    def voted_ratio(self, obj):
+        if not obj.view_total_score:
+            return mark_safe('<div style="width: 100px; height: 10px; border: 1px solid black"></div>')
+
+        percent = int(obj.count_voted * 100.0 / obj.count_total_participants)
+        return mark_safe('<div style="width: 100px; height: 10px; border: 1px solid black; background: #417690;">'
+                         f'<div style="width: {percent}px; height: 10px; background: #f5dd5d;"></div>'
+                         '</div>')
+
+    voted_ratio.short_description = 'Votes ratio'
 
 
 admin.site.register(Participant, ParticipantAdmin)

--- a/participants/api/serializers.py
+++ b/participants/api/serializers.py
@@ -7,6 +7,8 @@ from contests.models import Contest
 from countries.models import Country
 from participants.models import Participant
 
+from eurovision_project.settings import CACHES
+
 
 class ParticipantSerializer(serializers.ModelSerializer):
     artist = serializers.PrimaryKeyRelatedField(queryset=Artist.objects.all())
@@ -23,4 +25,5 @@ class ParticipantSerializer(serializers.ModelSerializer):
     def get_total_score(self, obj):
         """Get total score for this Participant from cache, or return None."""
 
-        return cache.get(f'participant{obj.pk}', default=None)
+        prefix = CACHES['default']['APPS_KEY_PREFIX']['participants']
+        return cache.get(f'{prefix}.{obj.pk}', default=None)

--- a/participants/api/serializers.py
+++ b/participants/api/serializers.py
@@ -23,4 +23,4 @@ class ParticipantSerializer(serializers.ModelSerializer):
     def get_total_score(self, obj):
         """Get total score for this Participant from cache, or return None."""
 
-        return cache.get(obj.pk, default=None)
+        return cache.get(f'participant{obj.pk}', default=None)

--- a/participants/models.py
+++ b/participants/models.py
@@ -6,6 +6,8 @@ from artists.models import Artist
 from contests.models import Contest
 from countries.models import Country
 
+from eurovision_project.settings import CACHES
+
 
 class Participant(models.Model):
     artist = models.ForeignKey(Artist, on_delete=models.CASCADE,)
@@ -27,7 +29,8 @@ class Participant(models.Model):
 
     @property
     def cached_total_score(self):
-        return cache.get(f'participant{self.id}')
+        prefix = CACHES['default']['APPS_KEY_PREFIX']['participants']
+        return cache.get(f'{prefix}.{self.id}')
 
     def __str__(self):
         return '{} - {} - {} - Eurovision {}'.format(

--- a/participants/models.py
+++ b/participants/models.py
@@ -1,5 +1,6 @@
 from django.apps import apps
 from django.db import models
+from django.core.cache import cache
 
 from artists.models import Artist
 from contests.models import Contest
@@ -23,6 +24,10 @@ class Participant(models.Model):
     @property
     def count_total_participants(self):
         return Participant.objects.filter(contest__year=self.contest.year).count()
+
+    @property
+    def cached_total_score(self):
+        return cache.get(f'participant{self.id}')
 
     def __str__(self):
         return '{} - {} - {} - Eurovision {}'.format(

--- a/votes/tasks.py
+++ b/votes/tasks.py
@@ -10,6 +10,9 @@ from django.db.models import Sum
 
 from celery import shared_task
 
+from eurovision_project.settings import CACHES
+
+
 CACHE_TTL = getattr(settings, 'CACHE_TTL', DEFAULT_TIMEOUT)
 
 logger = logging.getLogger('vote')
@@ -21,7 +24,8 @@ def recalculate_total_votes_for_participant(to_participant_id):
     total = Vote.objects.filter(to_participant=to_participant_id).aggregate(Sum('point'))
     total_score = total['point__sum']
 
-    cache.set(f'participant{to_participant_id}', total_score, CACHE_TTL)
+    prefix = CACHES['default']['APPS_KEY_PREFIX']['participants']
+    cache.set(f'{prefix}.{to_participant_id}', total_score, CACHE_TTL)
     logger.info(f'Score for participant {to_participant_id}: {total_score}. Caching...')
 
     return total_score

--- a/votes/tasks.py
+++ b/votes/tasks.py
@@ -21,7 +21,7 @@ def recalculate_total_votes_for_participant(to_participant_id):
     total = Vote.objects.filter(to_participant=to_participant_id).aggregate(Sum('point'))
     total_score = total['point__sum']
 
-    cache.set(to_participant_id, total_score, CACHE_TTL)
+    cache.set(f'participant{to_participant_id}', total_score, CACHE_TTL)
     logger.info(f'Score for participant {to_participant_id}: {total_score}. Caching...')
 
     return total_score


### PR DESCRIPTION
Fixed keys naming for Redis: keys in a cache is specified to include the app name and id to avoid conflicting between apps keys in cache in a future. Also added record with cached valued in an Django admin for participant app.